### PR TITLE
Update buy_post.feature

### DIFF
--- a/features/buy_post.feature
+++ b/features/buy_post.feature
@@ -62,7 +62,7 @@ Feature: Create buy orders
       "shares": 2
     }
     """
-    Then the response status code should be 404
+    Then the response status code should be 200
     And the response should be empty
 
   Scenario: Buy unknown portfolio


### PR DESCRIPTION
On the main README is specified that "New allocations can be bought, even if they are present or not on the portfolio." thus I thought this should return instead an HTTP_STATUS_OK.